### PR TITLE
Render templates with text/template, not html/template.

### DIFF
--- a/src/gcredstash/command/template.go
+++ b/src/gcredstash/command/template.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"gcredstash"
 	"github.com/mattn/go-shellwords"
-	"html/template"
+	"text/template"
 	"io/ioutil"
 	"os"
 	"os/exec"


### PR DESCRIPTION
The existing template implementation uses `html/template`, which automatically escapes the rendered output to be HTML-safe.

This causes problems when templating non-trivial data such as e.g. RSA keys. The rendered output is unusable for anything except in-browser display, unless you further process it to unescape the HTML entities.

Since this CLI tool doesn't have an HTML interface, I'm not sure why we would want escaped output by default.

This PR changes the template command to use `text/template` to avoid mutating the output.